### PR TITLE
feat: Commit Generated Documentation Artifacts back into repository

### DIFF
--- a/.github/workflows/documentation-release.yml
+++ b/.github/workflows/documentation-release.yml
@@ -3,141 +3,45 @@ name: Documentation Release
 on:
   push:
     branches: [ "main" ]
+    paths: ['docs/src/**']
   pull_request:
     branches: [ "main" ]
+    paths: ['docs/src/**']
 
   workflow_dispatch:
 
 jobs:
-  build:
+  gen_docs:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Pandoc
-        env:
-          PANDOC_VERSION: "3.1.9"
-        run: wget -qO- https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz | sudo tar xzf - --strip-components 1 -C /usr/local/
-
-      - name: Get TexLive Profile
-        run: |
-          mkdir tl_profile
-          curl https://raw.githubusercontent.com/Wandmalfarbe/pandoc-latex-template/master/.texlife.profile > tl_profile/.texlife.profile
-
-      - name: Create TexLive Installation Folder
-        env:
-          TEXLIVE_DIRECTORY: '/usr/local/texlive'
-        run: |
-          sudo mkdir -p ${TEXLIVE_DIRECTORY}
-          sudo chown -hR $(whoami) "$TEXLIVE_DIRECTORY"
-
-      - name: Restore Cache
-        uses: actions/cache/restore@v4
-        id: restore-cache
-        with:
-          path: /usr/local/texlive
-          key: ${{ runner.os }}-profile-${{ hashFiles('tl_profile') }}-v1
-
-      - name: Install TexLive
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        env:
-          REMOTE: http://mirror.ctan.org/systems/texlive/tlnet
-          INSTALL: '/tmp/install-texlive'
-        run: |
-          mkdir -p ${INSTALL}
-          curl -sSL ${REMOTE}/install-tl-unx.tar.gz | tar -xzv -C $INSTALL --strip-components=1
-          sudo ${INSTALL}/install-tl --no-gui --profile tl_profile/.texlife.profile
-          VERSION=$($INSTALL/install-tl --version | grep 'version' | grep -o '[0-9]\{4\}')
-          PLATFORM=$($INSTALL/install-tl --print-platform)
-          TEXLIVE_DIR="/usr/local/texlive/${VERSION}"
-          TEXBIN="/usr/local/texlive/${VERSION}/bin/${PLATFORM}"
-          echo "${TEXBIN}" >> $GITHUB_PATH
-          sudo chown -hR $(whoami) "$TEXLIVE_DIR"
-
-      - name: Initialization for tlmgr for TexLive Plugin System
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get update -qq && sudo apt-get install xzdec -y
-          tlmgr init-usertree
-
-      - name: Install LaTeX Packages
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: |
-          tlmgr install adjustbox background bidi csquotes footmisc footnotebackref fvextra mdframed pagecolor sourcecodepro sourcesanspro titling ulem upquote xurl hardwrap catchfile
-          # trial and error
-          tlmgr install letltxmacro zref everypage framed collectbox
-          # packages needed for the template
-          tlmgr install xecjk filehook unicode-math ucharcat pagecolor babel-german ly1 mweights sourcecodepro sourcesanspro mdframed needspace fvextra footmisc footnotebackref background
-          # packages only needed for some examples (that include packages via header-includes)
-          tlmgr install awesomebox fontawesome5
-          # packages only needed for some examples (example boxes-with-pandoc-latex-environment-and-tcolorbox)
-          tlmgr install tcolorbox pgf etoolbox environ trimspaces
-
-      - name: Cache Files
-        uses: actions/cache/save@v4
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        id: cache
-        with:
-          path: /usr/local/texlive
-          key: ${{ runner.os }}-profile-${{ hashFiles('tl_profile') }}-v1
-
-      - name: Register TexLive Environment Variables
-        if: steps.restore-cache.outputs.cache-hit == 'true'
-        env:
-          REMOTE: http://mirror.ctan.org/systems/texlive/tlnet
-          INSTALL: '/tmp/install-texlive'
-        run: |
-          mkdir -p ${INSTALL}
-          curl -sSL ${REMOTE}/install-tl-unx.tar.gz | tar -xzv -C $INSTALL --strip-components=1
-          VERSION=$($INSTALL/install-tl --version | grep 'version' | grep -o '[0-9]\{4\}')
-          PLATFORM=$($INSTALL/install-tl --print-platform)
-          TEXLIVE_DIR="/usr/local/texlive/${VERSION}"
-          TEXBIN="/usr/local/texlive/${VERSION}/bin/${PLATFORM}"
-          echo "${TEXBIN}" >> $GITHUB_PATH
-
-      - name: Setup Fonts & Image Conversion Utilities
-        run: sudo apt-get update -qq && sudo apt-get install fonts-noto-cjk poppler-utils -y
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-            python-version: '3.12'
-
-      - name: Install Pandoc-Python Filters
-        run: pip install pandoc-latex-environment
-
-      - name: Download Latest Eisvogel Template
-        env:
-          TEMPLATES_DIR: 'templates'
-          EISVOGEL_REPO: https://raw.githubusercontent.com/Wandmalfarbe/pandoc-latex-template
-          EISVOGEL_VERSION: v2.4.0
-        run: |
-          mkdir -p ${TEMPLATES_DIR}
-          sudo chown -hR $(whoami) "$TEMPLATES_DIR"
-          wget ${EISVOGEL_REPO}/${EISVOGEL_VERSION}/eisvogel.tex -O ${TEMPLATES_DIR}/eisvogel.latex
-
-      - name: Build Documentation Files
+      - name: Clean Documentation Dist Folder
         run: |
           rm -rf docs/dist
-          mkdir -p docs/dist
-          pandoc docs/src/documentation.md -o docs/dist/documentation.pdf --template "templates/eisvogel.latex" --listings
-          pandoc docs/src/specification.md -o docs/dist/specification.pdf --template "templates/eisvogel.latex" --listings
-          pandoc docs/src/testing.md -o docs/dist/testing.pdf --template "templates/eisvogel.latex" --listings
-          pandoc docs/src/whitepaper.md -o docs/dist/whitepaper.pdf --template "templates/eisvogel.latex" --listings
+          mkdir docs/dist
+      - name: DocGen - Programming Documentation
+        uses: docker://pandoc/extra:latest
+        with:
+          args: --listings --template https://raw.githubusercontent.com/Wandmalfarbe/pandoc-latex-template/master/eisvogel.tex --output=docs/dist/documentation.pdf "docs/src/documentation.md"
+
+      - name: DocGen - Specification Documentation
+        uses: docker://pandoc/extra:latest
+        with:
+          args: --listings --template https://raw.githubusercontent.com/Wandmalfarbe/pandoc-latex-template/master/eisvogel.tex --output=docs/dist/specification.pdf "docs/src/specification.md"
+            
+      - name: DocGen - Testing Documentation
+        uses: docker://pandoc/extra:latest
+        with:
+          args: --listings --template https://raw.githubusercontent.com/Wandmalfarbe/pandoc-latex-template/master/eisvogel.tex --output=docs/dist/testing.pdf "docs/src/testing.md"
+
+      - name: DocGen - Whitepaper Documentation
+        uses: docker://pandoc/extra:latest
+        with:
+          args: --listings --template https://raw.githubusercontent.com/Wandmalfarbe/pandoc-latex-template/master/eisvogel.tex --output=docs/dist/whitepaper.pdf "docs/src/whitepaper.md"
 
       - name: Upload Generated Documentation Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/dist/*
-
-      - name: Git Commit Generated Documentation Artifacts
-        id: auto-commit-action
-        if: steps.auto-commit-action.outputs.changes_detected == 'true'
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Documentation Artifacts

--- a/.github/workflows/documentation-release.yml
+++ b/.github/workflows/documentation-release.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   gen_docs:
     runs-on: ubuntu-latest
+
+    permissions:
+      content: write
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/documentation-release.yml
+++ b/.github/workflows/documentation-release.yml
@@ -133,6 +133,7 @@ jobs:
           path: docs/dist/*
 
       - name: Git Commit Generated Documentation Artifacts
+        id: auto-commit-action
         if: steps.auto-commit-action.outputs.changes_detected == 'true'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/documentation-release.yml
+++ b/.github/workflows/documentation-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      content: write
+      contents: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/documentation-release.yml
+++ b/.github/workflows/documentation-release.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/documentation-release.yml
+++ b/.github/workflows/documentation-release.yml
@@ -133,10 +133,7 @@ jobs:
           path: docs/dist/*
 
       - name: Git Commit Generated Documentation Artifacts
-        if: github.event_name == 'push'
-        run: |
-          git config --global user.name "Continuous Integration"
-          git config --global user.email "username@users.noreply.github.com"
-          git add docs/dist
-          git commit -m "Continuous Integration: Documentation Artifacts"
-          git push
+        if: steps.auto-commit-action.outputs.changes_detected == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Documentation Artifacts

--- a/.github/workflows/documentation-release.yml
+++ b/.github/workflows/documentation-release.yml
@@ -126,8 +126,17 @@ jobs:
           pandoc docs/src/testing.md -o docs/dist/testing.pdf --template "templates/eisvogel.latex" --listings
           pandoc docs/src/whitepaper.md -o docs/dist/whitepaper.pdf --template "templates/eisvogel.latex" --listings
 
-      - name: Upload Generated Documentation Files
+      - name: Upload Generated Documentation Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/dist/*
+
+      - name: Git Commit Generated Documentation Artifacts
+        if: github.event_name == 'push'
+        run: |
+          git config --global user.name "Continuous Integration"
+          git config --global user.email "username@users.noreply.github.com"
+          git add docs/dist
+          git commit -m "Continuous Integration: Documentation Artifacts"
+          git push

--- a/.github/workflows/documentation-release.yml
+++ b/.github/workflows/documentation-release.yml
@@ -1,9 +1,6 @@
 name: Documentation Release
 
 on:
-  push:
-    branches: [ "main" ]
-    paths: ['docs/src/**']
   pull_request:
     branches: [ "main" ]
     paths: ['docs/src/**']
@@ -45,3 +42,9 @@ jobs:
         with:
           name: docs
           path: docs/dist/*
+
+      - name: Git Commit Generated Documentation Artifacts
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Documentation Artifacts
+          file_pattern: '*.pdf'


### PR DESCRIPTION
# Description

Commits generated documentation PDF file(s) back into `docs/dist` folder, when PR gets merged into main branch.

Closes #16 

# Testing Guidelines

* Fork this repository for yourself and merge this branch and test by doing sample commits and see if generated docs are being committed back appropriately.