### PR TITLE
feat: Parse Return Statement(s)

### DIFF
--- a/src/ast/ast.go
+++ b/src/ast/ast.go
@@ -102,3 +102,17 @@ func (i *Identifier) expressionNode() {}
 func (i *Identifier) TokenLiteral() string {
 	return i.Token.Literal
 }
+
+// Return Statements consist solely of the keyword `return` and an expression.
+type ReturnStatement struct {
+	Token       token.Token // token.RETURN token
+	ReturnValue Expression
+}
+
+// Implementing Statement interface on ReturnStatement
+func (rs *ReturnStatement) statementNode() {}
+
+// Implementing the Node interface on ReturnStatement
+func (rs *ReturnStatement) TokenLiteral() string {
+	return rs.Token.Literal
+}

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -68,6 +68,8 @@ func (p *Parser) parseStatement() ast.Statement {
 	switch p.curToken.Type {
 	case token.LET:
 		return p.parseLetStatement()
+	case token.RETURN:
+		return p.parseReturnStatement()
 	default:
 		return nil
 	}
@@ -90,6 +92,21 @@ func (p *Parser) parseLetStatement() *ast.LetStatement {
 	}
 
 	// TODO: Skipping expressions until we encounter a semicolon
+	// TODO: Construct Expression
+	for !p.curTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+
+	return stmt
+}
+
+// Parse Return Statements down to ReturnKeyword Statement Node & ReturnValue-Expression Node
+func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
+	stmt := &ast.ReturnStatement{Token: p.curToken}
+
+	p.nextToken()
+
+	// TODO: Skipping the expressions until we encounter a semicolon
 	// TODO: Construct Expression
 	for !p.curTokenIs(token.SEMICOLON) {
 		p.nextToken()

--- a/src/parser/parser_test.go
+++ b/src/parser/parser_test.go
@@ -84,3 +84,38 @@ func testLetStatement(t *testing.T, s ast.Statement, name string) bool {
 
 	return true
 }
+
+func TestReturnStatements(t *testing.T) {
+	input := `
+	return 5;
+	return 10;
+	return 898;
+	`
+
+	l := lexer.New(input)
+	p := New(l)
+
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 3 {
+		t.Fatalf(
+			"program.Statements does not contain 3 statements. got %d",
+			len(program.Statements),
+		)
+	}
+
+	for _, stmt := range program.Statements {
+		returnStmt, ok := stmt.(*ast.ReturnStatement)
+
+		if !ok {
+			t.Errorf("stmt not *ast.ReturnStatement. got=%T", stmt)
+			continue
+		}
+
+		if returnStmt.TokenLiteral() != "return" {
+			t.Errorf("returnStmt.TokenLiteral not 'return', got %q",
+				returnStmt.TokenLiteral())
+		}
+	}
+}


### PR DESCRIPTION
#  Description

Adds the ability to parse return statements down into the keyword and the following expression (however the actual parsing of this expression is still yet to be implemented [even for let statements]

# Testing Guidelines

* Clone this branch
* cd into src
* Run `go test ./parser`
* Verify if all tests passed

Closes #20 